### PR TITLE
Initialize record_field_details_path

### DIFF
--- a/zcrmsdk/src/com/zoho/crm/api/util/utility.py
+++ b/zcrmsdk/src/com/zoho/crm/api/util/utility.py
@@ -71,7 +71,8 @@ class Utility(object):
             from ..initializer import Initializer
 
         last_modified_time = None
-
+        record_field_details_path = None        
+        
         try:
             with Utility.lock:
                 resources_path = os.path.join(Initializer.get_initializer().resource_path,


### PR DESCRIPTION
This fixes and issue where any exception entered on line 153 will fail, because line 154 references `record_field_details_path` which has not been set by that point. 